### PR TITLE
[Hotfix] Исправлена ошибка с редактированием профиля.

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -194,7 +194,7 @@ export const patchCurrentUser : IPatchUser = (
       res = { ...res, bio };
     }
     if (image) {
-      res = { ...res, link: image };
+      res = { ...res, image };
     }
     if (nickname) {
       res = { ...res, nickname };


### PR DESCRIPTION
При отправке профиля на сервер картинка пользователя передавалась в неверном поле: сервер ожидал image: <url>, а приходил link: <url>, и не принималась сервером.